### PR TITLE
Bump node version and use matrix

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,10 +11,10 @@ jobs:
     name: Publish package to NPM
     runs-on: [ubuntu-latest]
     steps:
-      - name: Use Node.js 10.x
+      - name: Use Node.js 12.x
         uses: actions/setup-node@v1
         with:
-          node-version: 10.x
+          node-version: 12.x
       - name: Checkout code
         uses: actions/checkout@v1
       - name: Get yarn cache dir

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,10 +12,10 @@ jobs:
     name: Lint code
     runs-on: [ubuntu-latest]
     steps:
-      - name: Use Node.js 10.x
+      - name: Use Node.js 12.x
         uses: actions/setup-node@v1
         with:
-          node-version: 10.x
+          node-version: 12.x
       - name: Checkout code
         uses: actions/checkout@v1
       - name: Get yarn cache dir
@@ -34,14 +34,18 @@ jobs:
         run: yarn lint
 
   test:
-    name: Run tests
+    name: Run tests on ${{ matrix.os }} and node ${{ matrix.node_version }}
     runs-on: [ubuntu-latest]
     needs: lint
+    strategy:
+      matrix:
+        node_version: ['10', '12']
+        os: [ubuntu-latest]
     steps:
-      - name: Use Node.js 10.x
+      - name: Use Node.js ${{ matrix.node_version }}
         uses: actions/setup-node@v1
         with:
-          node-version: 10.x
+          node-version: ${{ matrix.node_version }}
       - name: Checkout code
         uses: actions/checkout@v1
       - name: Get yarn cache dir

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
         run: yarn lint
 
   test:
-    name: Run tests on ${{ matrix.os }} and node ${{ matrix.node_version }}
+    name: Run tests with node ${{ matrix.node_version }} on ${{ matrix.os }}
     runs-on: [ubuntu-latest]
     needs: lint
     strategy:


### PR DESCRIPTION
Closes #4 

- Publish is bumped to 12 to match latest version.
- Lint is bumped to 12 (static quality is not tied to a version).
- Tests are runned on 10 and 12