### PR TITLE
Fix support for GET/HEAD/non body requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@
 SalesForcer is a wrapper around SalesForce API allowing to simply build single and composite requests.    
 It uses [axios](https://github.com/axios/axios) to make HTTP requests.
 
+**LIMITATIONS AND DISCLAIMER**  
+This library is in [pre 1.0.0 state](https://semver.org/#spec-item-4). Api and structure can change and break frequently.  
+Currently only `sobjects` requests are supported. It is not possible to compose `query` requests.
+
 
 ## Usage
 
@@ -42,7 +46,11 @@ const executor = new Exectutor({
    username: 'fakeUsername',
 });
 
-const request = new Request('POST', 'Task', {foo: 'bar'});
+const request = new Request({
+    method: 'POST',
+    sobject: 'Task',
+    body: { foo: 'bar' },
+});
 
 await executor.auth();
 const response = await executor.execute(request);
@@ -66,11 +74,19 @@ const composite = new Composite(true);
 composite
     .add({
         referenceId: 'NewLead',
-        request: new Request('POST', 'Lead', {foo: 'bar'}),
+        request: new Request({
+            method: 'POST',
+            sobject: 'Task',
+            body: { foo: 'bar' },
+        }),
     })
     .add({
         referenceId: 'AddTask',
-        request: new Request('POST', 'Task', {bar: 'baz', WhoId: '@{NewLead.id}'}),
+        request: new Request({
+            method: 'POST',
+            sobject: 'Task',
+            body: { bar: 'baz', WhoId: '@{NewLead.id}' },
+        }),
     });
 
 await executor.auth();
@@ -88,6 +104,11 @@ const response = await executor.execute(composite);
 - `apiVersion` \<[string]>
 - `axios` \<[AxiosInstance]>
 - returns: \<[Promise]\<any>>
+
+
+### interface: `Validable`
+#### `validate(): boolean | never;`
+- returns: \<[boolean]>
 
 
 ### class: `Executor`
@@ -109,18 +130,20 @@ const response = await executor.execute(composite);
 - returns: \<[Promise]\<any>>
 
 
-### class: `Request` implements `Executable`
-#### `constructor(method, sobject, body, apiVersion?)`
+### class: `Request` implements `Executable`, `Validable`
+#### `constructor({ method, sobject, body?, params?, qs?, apiVersion? });`
 - `method` \<[Method]>
 - `sobject` \<[string]>
 - `body` \<[object]>
-- `apiVersion` \<[string] | null>
+- `params` \<[Array]<[string]>>
+- `qs` \<[ParsedUrlQueryInput]>
+- `apiVersion` \<[string]>
 
 
 ### class: `Composite` implements `Executable`
-#### `constructor(allOrNone, apiVersion)`
+#### `constructor(allOrNone, apiVersion?)`
 - `allOrNone` \<[boolean]>
-- `apiVersion` \<[string] | null>
+- `apiVersion` \<[string]>
 
 #### `add({ request, referenceId }): Composite`
 - `method` \<[Method]>
@@ -160,9 +183,14 @@ This will:
 [string]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#String_type "String"
 [boolean]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type "Boolean"
 [object]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Objects "Object"
+[Array]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Indexed_collections_Arrays_and_typed_Arrays "Array"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [AxiosInstance]: https://github.com/axios/axios/blob/v0.19.0/index.d.ts#L123 "AxiosInstance"
+[ParsedUrlQueryInput]: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/querystring.d.ts#L13 "ParsedUrlQueryInput"
 [Method]: https://github.com/axios/axios/blob/v0.19.0/index.d.ts#L24 "Method"
 [Executable]: #interface-executable
 [Request]: #class-request-implements-executable
 [Composite]: #class-composite-implements-executable
+
+
+

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "devDependencies": {
     "@types/jest": "^24.0.23",
+    "@types/node": "^12.12.14",
     "@typescript-eslint/eslint-plugin": "^2.8.0",
     "@typescript-eslint/parser": "^2.8.0",
     "eslint": "^6.6.0",

--- a/src/Composite.spec.ts
+++ b/src/Composite.spec.ts
@@ -5,7 +5,11 @@ import mockedAxios from 'axios';
 describe('Composite.add', () => {
     it('adds a new CompositeRequest', () => {
         const c: Composite = new Composite(true);
-        const testRequest: Request = new Request('POST', 'Lead', {heck: 'yeah'});
+        const testRequest: Request = new Request({
+            method: 'POST',
+            sobject: 'Lead',
+            body: { heck: 'yeah' },
+        });
 
         expect(c.requests).toHaveLength(0);
 
@@ -18,7 +22,11 @@ describe('Composite.add', () => {
 
     it('can be chained', () => {
         const c: Composite = new Composite(true);
-        const testRequest: Request = new Request('POST', 'Lead', {heck: 'yeah'});
+        const testRequest: Request = new Request({
+            method: 'POST',
+            sobject: 'Lead',
+            body: { heck: 'yeah' },
+        });
 
         expect(c.requests).toHaveLength(0);
 
@@ -51,8 +59,16 @@ describe('Composite.buildUrl', () => {
 describe('Composite.buildPayload', () => {
     it('creates a payload with loaded requests', async() => {
         const c: Composite = new Composite(true);
-        const testFirst: Request = new Request('POST', 'Lead', {heck: 'yeah'});
-        const testNext: Request = new Request('POST', 'Task', {sup: 'bruh', WhoId: '@{NewLead.id}'});
+        const testFirst: Request = new Request({
+            method: 'POST',
+            sobject: 'Lead',
+            body: { heck: 'yeah' },
+        });
+        const testNext: Request = new Request({
+            method: 'POST',
+            sobject: 'Task',
+            body: {sup: 'bruh', WhoId: '@{NewLead.id}'},
+        });
 
         c
             .add({ referenceId: "NewLead", request: testFirst })
@@ -65,13 +81,43 @@ describe('Composite.buildPayload', () => {
         expect(payload.compositeRequest[0].referenceId).toBe('NewLead');
         expect(payload.compositeRequest[1].referenceId).toBe('AddTask');
     });
+
+    it('creates a payload with valid body usage', async() => {
+        const c: Composite = new Composite(true);
+        const testFirst: Request = new Request({
+            method: 'GET',
+            sobject: 'Lead',
+            params: ['THE_LEAD_ID'],
+        });
+        const testNext: Request = new Request({
+            method: 'POST',
+            sobject: 'Task',
+            body: {sup: 'bruh', WhoId: '@{NewLead.id}'},
+        });
+
+        c
+            .add({ referenceId: "NewLead", request: testFirst })
+            .add({ referenceId: 'AddTask', request: testNext });
+
+        const payload = c.buildPayload('v50.0');
+
+        expect(payload.compositeRequest[0]).not.toHaveProperty('body');
+    });
 });
 
 describe('Composite.execute', () => {
     it('should return data on success', async() => {
         const c: Composite = new Composite(true);
-        const testFirst: Request = new Request('POST', 'Lead', {heck: 'yeah'});
-        const testNext: Request = new Request('POST', 'Task', {sup: 'bruh', WhoId: '@{NewLead.id}'});
+        const testFirst: Request = new Request({
+            method: 'POST',
+            sobject: 'Lead',
+            body: { heck: 'yeah' },
+        });
+        const testNext: Request = new Request({
+            method: 'POST',
+            sobject: 'Task',
+            body: {sup: 'bruh', WhoId: '@{NewLead.id}'},
+        });
 
         c
             .add({ referenceId: "NewLead", request: testFirst })
@@ -91,8 +137,16 @@ describe('Composite.execute', () => {
 
     it('throws on error', async() => {
         const c: Composite = new Composite(true);
-        const testFirst: Request = new Request('POST', 'Lead', {heck: 'yeah'});
-        const testNext: Request = new Request('POST', 'Task', {sup: 'bruh', WhoId: '@{NewLead.id}'});
+        const testFirst: Request = new Request({
+            method: 'POST',
+            sobject: 'Lead',
+            body: { heck: 'yeah' },
+        });
+        const testNext: Request = new Request({
+            method: 'POST',
+            sobject: 'Task',
+            body: {sup: 'bruh', WhoId: '@{NewLead.id}'},
+        });
 
         c
             .add({ referenceId: "NewLead", request: testFirst })

--- a/src/Composite.ts
+++ b/src/Composite.ts
@@ -6,7 +6,7 @@ interface CompositeRequestPayload {
     method: Method;
     referenceId: string;
     url: string;
-    body: object;
+    body?: object;
 }
 
 interface CompositePayload {
@@ -26,12 +26,15 @@ class Composite implements Executable {
 
     allOrNone: boolean;
     requests: Array<CompositeRequest>;
-    apiVersion: string | null;
+    apiVersion?: string;
 
-    constructor(allOrNone: boolean, apiVersion: string | null = null) {
+    constructor(allOrNone: boolean, apiVersion?: string) {
         this.allOrNone = allOrNone;
         this.requests = [];
-        this.apiVersion = apiVersion;
+
+        if (apiVersion) {
+            this.apiVersion = apiVersion;
+        }
     }
 
     add(compositeRequest: CompositeRequest): Composite {
@@ -47,12 +50,18 @@ class Composite implements Executable {
         };
 
         for (const cRequest of this.requests) {
-            payload.compositeRequest.push({
+            cRequest.request.validate();
+
+            const p: CompositeRequestPayload = {
                 method: cRequest.request.method,
                 referenceId: cRequest.referenceId,
                 url: cRequest.request.buildUrl(apiVersion),
-                body: cRequest.request.body,
-            })
+            };
+            if (cRequest.request.body) {
+                p.body = cRequest.request.body;
+            }
+
+            payload.compositeRequest.push(p);
         }
 
         return payload;

--- a/src/Request.ts
+++ b/src/Request.ts
@@ -1,35 +1,76 @@
+import * as qs from 'querystring';
 import Executable from "./Executable";
+import Validable from "./Validable";
 import {AxiosInstance, Method} from 'axios';
 
-class Request implements Executable {
+interface RequestConfig {
+    method: Method;
+    sobject: string;
+    body?: object;
+    params?: Array<string>;
+    qs?: qs.ParsedUrlQueryInput;
+    apiVersion?: string;
+}
 
-    static readonly urlPrefix = '/services/data/';
-    static readonly urlSuffix = '/sobjects/';
+class Request implements Executable, Validable {
+    static readonly urlPrefix: string = '/services/data/';
+    static readonly urlSuffix: string = '/sobjects/';
+    static readonly methodBodyExclude: Array<Method> = ['GET', 'HEAD'];
 
     method: Method;
     sobject: string;
-    body: object;
-    apiVersion: string | null;
+    body?: object;
+    params?: Array<string>;
+    qs?: qs.ParsedUrlQueryInput;
+    apiVersion?: string;
 
-    constructor(method: Method, sobject: string, body: object, apiVersion: string | null = null) {
+    constructor({
+        method,
+        sobject,
+        body,
+        params,
+        qs,
+        apiVersion,
+    }: RequestConfig) {
         this.method = method;
         this.sobject = sobject;
         this.body = body;
-        this.apiVersion = apiVersion;
+
+        if (qs) {
+            this.qs = qs;
+        }
+        if (params) {
+            this.params = params;
+        }
+        if (apiVersion) {
+            this.apiVersion = apiVersion;
+        }
     }
 
     buildUrl(apiVersion: string): string {
-        return [
+        let url: string = [
             Request.urlPrefix,
             this.apiVersion || apiVersion,
             Request.urlSuffix,
             this.sobject,
         ].join('');
+
+        if (this.params) {
+            url += '/' + this.params.join('/');
+        }
+
+        if (this.qs) {
+            url += '?' + qs.encode(this.qs);
+        }
+
+        return url;
     }
 
     // Data from external APIs could be anything and could also change
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     async execute(apiVersion: string, axios: AxiosInstance): Promise<any> {
+        this.validate();
+
         const res = await axios.request({
             url: this.buildUrl(apiVersion),
             method: this.method,
@@ -39,6 +80,13 @@ class Request implements Executable {
         return res.data;
     }
 
+    validate(): boolean | never {
+        if (Request.methodBodyExclude.indexOf(this.method) !== -1 && this.body) {
+            throw new Error('\'body\' is not supported with GET or HEAD methods.');
+        }
+
+        return true;
+    }
 }
 
 export default Request;

--- a/src/Validable.ts
+++ b/src/Validable.ts
@@ -1,0 +1,5 @@
+interface Validable {
+    validate(): boolean | never;
+}
+
+export default Validable;

--- a/yarn.lock
+++ b/yarn.lock
@@ -356,6 +356,11 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.3.tgz#bdfd69d61e464dcc81b25159c270d75a73c1a636"
   integrity sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==
 
+"@types/node@^12.12.14":
+  version "12.12.14"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.14.tgz#1c1d6e3c75dba466e0326948d56e8bd72a1903d2"
+  integrity sha512-u/SJDyXwuihpwjXy7hOOghagLEV1KdAST6syfnOk6QZAMzZuWZqXy5aYYZbh8Jdpd4escVFP0MvftHNDb9pruA==
+
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"


### PR DESCRIPTION
**All changes are breaking**
- fix support of GET/HEAD requests not using any body.
- add clean api to use url parameters such has in GET [...]/Lead/{ID OF THE LEAD}
- add api for query string
- change Request constructor to be more easily composable.
- add validable Interface