### PR TITLE
Add auto auth on Executor.execute

### DIFF
--- a/src/Executor.spec.ts
+++ b/src/Executor.spec.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import Executor from './Executor';
+import Query from "./Query";
 
 describe('Executor.auth', () => {
     it('sets axios and token on success', async () => {
@@ -67,5 +68,48 @@ describe('Executor.auth', () => {
 
         await expect(e.auth()).rejects.toBeTruthy();
         expect(axios.post).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('Executor.execute', () => {
+    it('auto auth on execution if not aleady authed', async () => {
+        const e: Executor = new Executor({
+            apiVersion: "v0.0",
+            baseUrl: "https://my.fake.tld",
+            authUrl: "https://auth.my.fake.tld",
+            clientId: "fakeClientId",
+            clientSecret: "fakeClientSecret",
+            grantType: "password",
+            password: "fakeValidPassword",
+            username: "fakeUsername",
+        });
+
+        // Add spy on auth to track calls
+        const spy = jest.spyOn(e, 'auth');
+
+        (axios.post as jest.Mock) = jest.fn(async() => {
+            return {
+                data: {
+                    "access_token": "fakeAccessToken",
+                    "instance_url": "https://my.fake.tld",
+                    "id": "https://my.fake.tld/id/00D1X0000008bP2UAI/0051t000003LPVHAA4",
+                    "token_type": "Bearer",
+                    "issued_at": "1573829868942",
+                    "signature": "RmFrZSBzaWduYXR1cmU=",
+                },
+                status: 200,
+                statusText: 'OK',
+            }
+        });
+
+        // Make a dummy request
+        const q: Query = new Query({
+            query: 'select id from contact where name = \'Howard Jones\'',
+        });
+        (q.execute as jest.Mock) = jest.fn(async() => { return { data: true } });
+
+        await e.execute(q);
+
+        expect(spy).toHaveBeenCalledTimes(1);
     });
 });

--- a/src/Executor.ts
+++ b/src/Executor.ts
@@ -81,9 +81,11 @@ class Executor {
     // Data from external APIs could be anything and could also change
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     async execute(request: Executable): Promise<any> {
-        if (this.axios) {
-            return await request.execute(this.apiVersion, this.axios);
+        if (!this.axios) {
+            await this.auth();
         }
+
+        return await request.execute(this.apiVersion, this.axios as AxiosInstance);
     }
 }
 


### PR DESCRIPTION
Add call to `Executor.auth()` when no authentication has been done before when running `Executor.execute(Executable)`