### PR TITLE
Simplify Auth parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ It uses [axios](https://github.com/axios/axios) to make HTTP requests.
 
 **LIMITATIONS AND DISCLAIMER**  
 This library is in [pre 1.0.0 state](https://semver.org/#spec-item-4). Api and structure can change and break frequently.  
-Currently only `sobjects`, `query` and `composite` requests are supported.
+Currently only `sobjects`, `query` and `composite` requests are supported.  
+Authentification only supports `grant_type=password`.
 
 
 ## Documentation

--- a/docs/api.md
+++ b/docs/api.md
@@ -36,6 +36,7 @@ Table of contents:
 
 Auth is the only class holding the mean to connect with Salesforce.  
 It is required to execute any instance of classes implementing [Executable].
+*Only `grant_type=password` is supported.*
 ```js
 const { Auth } = require('@digitregroup/salesforcer');
 
@@ -44,7 +45,6 @@ const auth = new Auth({
     baseUrl: 'https://my.fake.tld',
     clientId: 'fakeClientId',
     clientSecret: 'fakeClientSecret',
-    grantType: 'password',
     password: 'fakeValidPassword',
     username: 'fakeUsername',
 });
@@ -53,7 +53,6 @@ const auth = new Auth({
 #### constructor(authConfig)
 - `authConfig` <[Object]>
   - `baseUrl` <[string]> The base url of the Salesforce instance to be queried.
-  - `grantType` <[string]> The grant type to authenticate with Salesforce. 
   - `clientId` <[string]> The client id used to authenticate with Salesforce.
   - `clientSecret` <[string]> The client secret used to authenticate with Salesforce.
   - `username` <[string]> The username used to authenticate with Salesforce.

--- a/docs/api.md
+++ b/docs/api.md
@@ -12,7 +12,7 @@ Table of contents:
 - [class: Auth](#class-auth)
     * [auth.constructor(authConfig)](#constructorauthconfig)
     * [auth.getApiVersion()](#authgetapiversion)
-    * [auth.getInstance()](#authgetinstance)
+    * [auth.getInstanceUrl()](#authgetinstance)
     * [auth.getToken()](#authgettoken)
     * [auth.revoke()](#authrevoke)
 - [class: Query](#class-query)
@@ -42,7 +42,6 @@ const { Auth } = require('@digitregroup/salesforcer');
 const auth = new Auth({
     apiVersion: 'v0.0',
     baseUrl: 'https://my.fake.tld',
-    authUrl: 'https://auth.my.fake.tld',
     clientId: 'fakeClientId',
     clientSecret: 'fakeClientSecret',
     grantType: 'password',
@@ -53,13 +52,12 @@ const auth = new Auth({
 
 #### constructor(authConfig)
 - `authConfig` <[Object]>
-  - `authUrl` <[string]> The Salesforce url to authentify againts.
+  - `baseUrl` <[string]> The base url of the Salesforce instance to be queried.
   - `grantType` <[string]> The grant type to authenticate with Salesforce. 
   - `clientId` <[string]> The client id used to authenticate with Salesforce.
   - `clientSecret` <[string]> The client secret used to authenticate with Salesforce.
   - `username` <[string]> The username used to authenticate with Salesforce.
   - `password` <[string]> The password used to authenticate with Salesforce.
-  - `baseUrl` <[string]> The base url of the Salesforce instance to be queried.
   - `apiVersion` <[string]> The default api version to be used with this connection.
 
 #### auth.getApiVersion()
@@ -67,7 +65,7 @@ const auth = new Auth({
 
 Returns the api version defined in Auth.
 
-#### auth.getInstance()
+#### auth.getInstanceUrl()
 - returns: <[Promise]<[string]>>
 
 Returns the instance url returned by Salesforce when authenticating.  

--- a/src/Auth.spec.ts
+++ b/src/Auth.spec.ts
@@ -8,7 +8,6 @@ describe('Auth.getToken', () => {
         const auth: Auth = new Auth({
             apiVersion: 'v0.0',
             baseUrl: 'https://my.fake.tld',
-            authUrl: 'https://auth.my.fake.tld',
             clientId: 'fakeClientId',
             clientSecret: 'fakeClientSecret',
             grantType: 'password',
@@ -44,7 +43,6 @@ describe('Auth.getToken', () => {
         const auth: Auth = new Auth({
             apiVersion: 'v0.0',
             baseUrl: 'https://my.fake.tld',
-            authUrl: 'https://auth.my.fake.tld',
             clientId: 'fakeClientId',
             clientSecret: 'fakeClientSecret',
             grantType: 'password',
@@ -85,7 +83,6 @@ describe('Auth.getToken', () => {
         const auth: Auth = new Auth({
             apiVersion: 'v0.0',
             baseUrl: 'https://my.fake.tld',
-            authUrl: 'https://auth.my.fake.tld',
             clientId: 'fakeClientId',
             clientSecret: 'fakeClientSecret',
             grantType: 'password',

--- a/src/Auth.spec.ts
+++ b/src/Auth.spec.ts
@@ -10,7 +10,6 @@ describe('Auth.getToken', () => {
             baseUrl: 'https://my.fake.tld',
             clientId: 'fakeClientId',
             clientSecret: 'fakeClientSecret',
-            grantType: 'password',
             password: 'fakeValidPassword',
             username: 'fakeUsername',
         });
@@ -45,7 +44,6 @@ describe('Auth.getToken', () => {
             baseUrl: 'https://my.fake.tld',
             clientId: 'fakeClientId',
             clientSecret: 'fakeClientSecret',
-            grantType: 'password',
             password: 'fakeValidPassword',
             username: 'fakeUsername',
         });
@@ -85,7 +83,6 @@ describe('Auth.getToken', () => {
             baseUrl: 'https://my.fake.tld',
             clientId: 'fakeClientId',
             clientSecret: 'fakeClientSecret',
-            grantType: 'password',
             password: 'fakeInvalidPassword',
             username: 'fakeUsername',
         });

--- a/src/Auth.ts
+++ b/src/Auth.ts
@@ -2,7 +2,6 @@ import axios, {AxiosResponse} from 'axios';
 
 export interface AuthConfig {
     baseUrl: string;
-    grantType: string;
     clientId: string;
     clientSecret: string;
     username: string;
@@ -21,9 +20,9 @@ export interface SalesforceAuthResponse {
 
 export default class Auth {
     static readonly path: string = '/services/oauth2/token';
+    static readonly grantType: string = 'password';
 
     private readonly baseUrl: string;
-    private readonly grantType: string;
     private readonly clientId: string;
     private readonly clientSecret: string;
     private readonly username: string;
@@ -33,7 +32,6 @@ export default class Auth {
     private authPayload?: SalesforceAuthResponse;
 
     public constructor({
-        grantType,
         clientId,
         clientSecret,
         username,
@@ -42,7 +40,6 @@ export default class Auth {
         apiVersion,
     }: AuthConfig) {
         this.baseUrl = baseUrl;
-        this.grantType = grantType;
         this.clientId = clientId;
         this.clientSecret = clientSecret;
         this.username = username;
@@ -81,11 +78,11 @@ export default class Auth {
                 null,
                 {
                     params: {
-                        'grant_type': this.grantType,
+                        'grant_type': Auth.grantType,
                         'client_id': this.clientId,
                         'client_secret': this.clientSecret,
-                        username: this.username,
-                        password: this.password,
+                        'username': this.username,
+                        'password': this.password,
                     },
                 },
             );

--- a/src/Auth.ts
+++ b/src/Auth.ts
@@ -1,13 +1,12 @@
 import axios, {AxiosResponse} from 'axios';
 
 export interface AuthConfig {
-    authUrl: string;
+    baseUrl: string;
     grantType: string;
     clientId: string;
     clientSecret: string;
     username: string;
     password: string;
-    baseUrl: string;
     apiVersion: string;
 }
 
@@ -21,19 +20,19 @@ export interface SalesforceAuthResponse {
 }
 
 export default class Auth {
-    private readonly authUrl: string;
+    static readonly path: string = '/services/oauth2/token';
+
+    private readonly baseUrl: string;
     private readonly grantType: string;
     private readonly clientId: string;
     private readonly clientSecret: string;
     private readonly username: string;
     private readonly password: string;
-    private readonly baseUrl: string;
     private readonly apiVersion: string;
 
     private authPayload?: SalesforceAuthResponse;
 
     public constructor({
-        authUrl,
         grantType,
         clientId,
         clientSecret,
@@ -42,14 +41,12 @@ export default class Auth {
         baseUrl,
         apiVersion,
     }: AuthConfig) {
-        this.authUrl = authUrl;
+        this.baseUrl = baseUrl;
         this.grantType = grantType;
         this.clientId = clientId;
         this.clientSecret = clientSecret;
         this.username = username;
         this.password = password;
-
-        this.baseUrl = baseUrl;
         this.apiVersion = apiVersion;
     }
 
@@ -57,7 +54,7 @@ export default class Auth {
         return this.apiVersion;
     }
 
-    public async getInstance(): Promise<string> {
+    public async getInstanceUrl(): Promise<string> {
         if (!this.authPayload) {
             this.authPayload = await this.authenticate();
         }
@@ -80,7 +77,7 @@ export default class Auth {
     private async authenticate(): Promise<SalesforceAuthResponse> {
         try {
             const response: AxiosResponse<SalesforceAuthResponse> = await axios.post(
-                this.authUrl,
+                this.baseUrl + Auth.path,
                 null,
                 {
                     params: {

--- a/src/Composite.spec.ts
+++ b/src/Composite.spec.ts
@@ -13,7 +13,6 @@ import {
 const auth: Auth = new Auth({
     apiVersion: 'v50.5',
     baseUrl: 'https://my.fake.tld',
-    authUrl: 'https://auth.my.fake.tld',
     clientId: 'fakeClientId',
     clientSecret: 'fakeClientSecret',
     grantType: 'password',
@@ -21,7 +20,7 @@ const auth: Auth = new Auth({
     username: 'fakeUsername',
 });
 
-(auth.getInstance as jest.Mock) = jest.fn(async() => 'https://my.fake.tld');
+(auth.getInstanceUrl as jest.Mock) = jest.fn(async() => 'https://my.fake.tld');
 (auth.getToken as jest.Mock) = jest.fn(async() => 'fakeAccessToken');
 
 

--- a/src/Composite.spec.ts
+++ b/src/Composite.spec.ts
@@ -15,7 +15,6 @@ const auth: Auth = new Auth({
     baseUrl: 'https://my.fake.tld',
     clientId: 'fakeClientId',
     clientSecret: 'fakeClientSecret',
-    grantType: 'password',
     password: 'fakeInvalidPassword',
     username: 'fakeUsername',
 });

--- a/src/Composite.ts
+++ b/src/Composite.ts
@@ -65,7 +65,7 @@ export default class Composite implements Executable {
 
     private async buildUrl(auth: Auth): Promise<string> {
         return [
-            await auth.getInstance(),
+            await auth.getInstanceUrl(),
             Composite.pathPrefix,
             this.apiVersion || auth.getApiVersion(),
             Composite.pathSuffix,

--- a/src/Query.spec.ts
+++ b/src/Query.spec.ts
@@ -7,7 +7,6 @@ import {QueryResponse, SalesforceRecord} from './Responses';
 const auth: Auth = new Auth({
     apiVersion: 'v50.5',
     baseUrl: 'https://my.fake.tld',
-    authUrl: 'https://auth.my.fake.tld',
     clientId: 'fakeClientId',
     clientSecret: 'fakeClientSecret',
     grantType: 'password',
@@ -15,7 +14,7 @@ const auth: Auth = new Auth({
     username: 'fakeUsername',
 });
 
-(auth.getInstance as jest.Mock) = jest.fn(async() => 'https://my.fake.tld');
+(auth.getInstanceUrl as jest.Mock) = jest.fn(async() => 'https://my.fake.tld');
 (auth.getToken as jest.Mock) = jest.fn(async() => 'fakeAccessToken');
 
 interface TestRecord extends SalesforceRecord {

--- a/src/Query.spec.ts
+++ b/src/Query.spec.ts
@@ -9,7 +9,6 @@ const auth: Auth = new Auth({
     baseUrl: 'https://my.fake.tld',
     clientId: 'fakeClientId',
     clientSecret: 'fakeClientSecret',
-    grantType: 'password',
     password: 'fakeInvalidPassword',
     username: 'fakeUsername',
 });

--- a/src/Query.ts
+++ b/src/Query.ts
@@ -27,7 +27,7 @@ export default class Query implements Executable, Composable {
 
     public async buildUrl(auth: Auth): Promise<string> {
         return [
-            await auth.getInstance(),
+            await auth.getInstanceUrl(),
             Query.pathPrefix,
             this.apiVersion || auth.getApiVersion(),
             Query.pathSuffix,

--- a/src/SObjects.spec.ts
+++ b/src/SObjects.spec.ts
@@ -7,7 +7,6 @@ import {RecordCreateResponse} from './Responses';
 const auth: Auth = new Auth({
     apiVersion: 'v50.5',
     baseUrl: 'https://my.fake.tld',
-    authUrl: 'https://auth.my.fake.tld',
     clientId: 'fakeClientId',
     clientSecret: 'fakeClientSecret',
     grantType: 'password',
@@ -15,7 +14,7 @@ const auth: Auth = new Auth({
     username: 'fakeUsername',
 });
 
-(auth.getInstance as jest.Mock) = jest.fn(async() => 'https://my.fake.tld');
+(auth.getInstanceUrl as jest.Mock) = jest.fn(async() => 'https://my.fake.tld');
 (auth.getToken as jest.Mock) = jest.fn(async() => 'fakeAccessToken');
 
 

--- a/src/SObjects.spec.ts
+++ b/src/SObjects.spec.ts
@@ -9,7 +9,6 @@ const auth: Auth = new Auth({
     baseUrl: 'https://my.fake.tld',
     clientId: 'fakeClientId',
     clientSecret: 'fakeClientSecret',
-    grantType: 'password',
     password: 'fakeInvalidPassword',
     username: 'fakeUsername',
 });

--- a/src/SObjects.ts
+++ b/src/SObjects.ts
@@ -45,7 +45,7 @@ export default class SObjects implements Executable, Composable {
 
     public async buildUrl(auth: Auth): Promise<string> {
         let url: string = [
-            await auth.getInstance(),
+            await auth.getInstanceUrl(),
             SObjects.pathPrefix,
             this.apiVersion || auth.getApiVersion(),
             SObjects.pathSuffix,


### PR DESCRIPTION
- Remove `authUrl` in favour of `baseUrl`.  
The authentication url can be determined from the base url.  
Once authorised the instance url returned by salesforce will be used.

- Rename `getInstance` into `getInstanceUrl`
`getInstance` sounded like a singleton access.

- Remove `grantType` parameters
Its only supported value would be 'password' as of now and even if other grant could be possible the code only allow that one.