### PR TITLE
Add null on composite (PATCH) and fix typo

### DIFF
--- a/src/Composite.spec.ts
+++ b/src/Composite.spec.ts
@@ -95,7 +95,7 @@ describe('Composite.execute', () => {
 
                     compositeResponse.push({
                         body,
-                        referenceID: r.referenceId,
+                        referenceId: r.referenceId,
                         httpHeaders: new Map([['Location', r.url + '/001R00000033I6AIAU']]),
                         httpStatusCode: 201,
                     });
@@ -120,8 +120,8 @@ describe('Composite.execute', () => {
         expect(requestParam).toHaveProperty('headers.Authorization');
 
         expect(data.compositeResponse).toHaveLength(2);
-        expect(data.compositeResponse[0].referenceID).toBe('NewLead');
-        expect(data.compositeResponse[1].referenceID).toBe('AddTask');
+        expect(data.compositeResponse[0].referenceId).toBe('NewLead');
+        expect(data.compositeResponse[1].referenceId).toBe('AddTask');
     });
 
     it('throws on error', async() => {
@@ -137,7 +137,7 @@ describe('Composite.execute', () => {
 
                     compositeResponse.push({
                         body,
-                        referenceID: 'badContact',
+                        referenceId: 'badContact',
                         httpHeaders: new Map(),
                         httpStatusCode: 400,
                     });

--- a/src/Responses.ts
+++ b/src/Responses.ts
@@ -17,10 +17,10 @@ export interface CompositeResponse extends SalesforceResponse {
 }
 
 export interface CompositeSubrequestResponse {
-    body: SalesforceResponse | SalesforceError;
+    body: SalesforceResponse | SalesforceError | null;
     httpHeaders: Map<string, string>;
     httpStatusCode: number;
-    referenceID: string;
+    referenceId: string;
 }
 
 /** A marker interface for easyier use in SObjects */


### PR DESCRIPTION
Add `null` as a body type in `CompositeSubrequestResponse`. Null is found in case of a PATCH.  
Fix typo in `CompositeSubrequestResponse`, `referenceID` in place of `referenceId`.