### PR TITLE
URL encode better than white space replace

### DIFF
--- a/src/Query.spec.ts
+++ b/src/Query.spec.ts
@@ -44,6 +44,17 @@ describe('Query.buildUrl', () => {
             '/services/data/v50.5/query/?q=select+id+from+contact+where+name+=+\'Howard+Jones\'',
         );
     });
+
+    it('returns url with special characters encoded', async() => {
+        const query: Query = new Query({
+            query: 'select id from contact where name LIKE \'%Howard Jones\'',
+        });
+        const url: string = await query.buildUrl(auth);
+
+        expect(url).toEqual(
+            '/services/data/v50.5/query/?q=select+id+from+contact+where+name+LIKE+\'%25Howard+Jones\'',
+        );
+    });
 });
 
 describe('Query.execute', () => {

--- a/src/Query.ts
+++ b/src/Query.ts
@@ -26,12 +26,14 @@ export default class Query implements Executable, Composable {
     }
 
     public buildUrl(auth: Auth): string {
-        return [
-            Query.pathPrefix,
-            this.apiVersion || auth.getApiVersion(),
-            Query.pathSuffix,
-            '?q=' + this.query.replace(/\s/g, '+'),
-        ].join('');
+        return encodeURI(
+            [
+                Query.pathPrefix,
+                this.apiVersion || auth.getApiVersion(),
+                Query.pathSuffix,
+                '?q=' + this.query,
+            ].join(''),
+        ).replace(/%20/g, '+');
     }
 
     public async execute<T extends SalesforceRecord>(auth: Auth): Promise<QueryResponse<T>> {


### PR DESCRIPTION
WIP

This first step is to set an encoded URL when building the query URL.

Is that OK ?