### PR TITLE
Change query encoding to user side

### DIFF
--- a/src/Query.spec.ts
+++ b/src/Query.spec.ts
@@ -45,14 +45,18 @@ describe('Query.buildUrl', () => {
         );
     });
 
-    it('returns url with special characters encoded', async() => {
+    it('handles multiline and escaped string', async() => {
         const query: Query = new Query({
-            query: 'select id from contact where name LIKE \'%Howard Jones\'',
+            query: `
+SELECT Id
+FROM Contact
+WHERE Email LIKE '${encodeURIComponent('test+woot@domain.%')}'
+            `,
         });
         const url: string = await query.buildUrl(auth);
 
         expect(url).toEqual(
-            '/services/data/v50.5/query/?q=select+id+from+contact+where+name+LIKE+\'%25Howard+Jones\'',
+            '/services/data/v50.5/query/?q=SELECT+Id+FROM+Contact+WHERE+Email+LIKE+\'test%2Bwoot%40domain.%25\'',
         );
     });
 });

--- a/src/Query.ts
+++ b/src/Query.ts
@@ -26,14 +26,14 @@ export default class Query implements Executable, Composable {
     }
 
     public buildUrl(auth: Auth): string {
-        return encodeURI(
-            [
-                Query.pathPrefix,
-                this.apiVersion || auth.getApiVersion(),
-                Query.pathSuffix,
-                '?q=' + this.query,
-            ].join(''),
-        ).replace(/%20/g, '+');
+        return [
+            Query.pathPrefix,
+            this.apiVersion || auth.getApiVersion(),
+            Query.pathSuffix,
+            '?q=' + this.query.trim().replace(/\s+/g, ' '),
+        ]
+            .join('')
+            .replace(/\ /g, '+');
     }
 
     public async execute<T extends SalesforceRecord>(auth: Auth): Promise<QueryResponse<T>> {


### PR DESCRIPTION
Because a single query would have 2 "parts" that would use 2 encoding -
on one side the actual soql has '+' for spaces, on the other a string
test might need to have some encodable chars in it ('%', '@', '+').
This would have some conflicts and encoding in the lib would create some
double encoding and break the whole thing.

There is no fully fledge sql like replacement thing in here so the
escaping is moved to the user side.

Exemple usage:
```ts
const query: Query = new Query({
	query: `
SELECT Id
FROM Contact
WHERE Email LIKE '${encodeURIComponent('test+woot@domain.%')}'
    `,
});
```
